### PR TITLE
add: OpenRouter provider

### DIFF
--- a/ai_providers/openrouter_provider.py
+++ b/ai_providers/openrouter_provider.py
@@ -1,0 +1,87 @@
+"""
+OpenRouter Provider
+"""
+
+from typing import Dict, Optional
+import requests
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class OpenRouterProvider:
+    """OpenRouter API provider."""
+    
+    def __init__(self, config: Dict):
+        """Initialize OpenRouter provider."""
+        self.config = config
+        self.api_key = config.get('api_key')
+        self.model = config.get('model', 'openai/gpt-4o')
+        self.temperature = config.get('temperature', 0.7)
+        self.max_tokens = config.get('max_tokens', 2000)
+        self.base_url = config.get('base_url', 'https://openrouter.ai/api/v1')
+        self.timeout = config.get('timeout', 30)
+        
+        if not self.api_key:
+            raise ValueError("OpenRouter API key not provided")
+        
+        self.headers = {
+            'Authorization': f'Bearer {self.api_key}',
+            'Content-Type': 'application/json',
+            'HTTP-Referer': 'https://github.com/deep-eye/deep-eye',  # Optional: for analytics
+            'X-Title': 'Deep Eye Security Scanner'  # Optional: for analytics
+        }
+    
+    def generate(self, prompt: str, **kwargs) -> str:
+        """
+        Generate response using OpenRouter.
+        
+        Args:
+            prompt: Input prompt
+            **kwargs: Additional arguments
+            
+        Returns:
+            Generated response
+        """
+        try:
+            payload = {
+                'model': kwargs.get('model', self.model),
+                'messages': [
+                    {
+                        'role': 'system',
+                        'content': 'You are a security expert specializing in penetration testing and vulnerability research.'
+                    },
+                    {
+                        'role': 'user',
+                        'content': prompt
+                    }
+                ],
+                'temperature': kwargs.get('temperature', self.temperature),
+                'max_tokens': kwargs.get('max_tokens', self.max_tokens)
+            }
+            
+            response = requests.post(
+                f'{self.base_url}/chat/completions',
+                headers=self.headers,
+                json=payload,
+                timeout=self.timeout
+            )
+            
+            response.raise_for_status()
+            result = response.json()
+            
+            if 'choices' in result and len(result['choices']) > 0:
+                return result['choices'][0]['message']['content']
+            else:
+                logger.error("No choices in OpenRouter response")
+                return ""
+        
+        except requests.exceptions.RequestException as e:
+            logger.error(f"OpenRouter API request error: {e}")
+            raise
+        except KeyError as e:
+            logger.error(f"OpenRouter response parsing error: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"OpenRouter generation error: {e}")
+            raise

--- a/ai_providers/provider_manager.py
+++ b/ai_providers/provider_manager.py
@@ -68,6 +68,15 @@ class AIProviderManager:
                 logger.info("Mistral provider initialized")
             except Exception as e:
                 logger.warning(f"Failed to initialize Mistral provider: {e}")
+        
+        # OpenRouter
+        if ai_config.get('openrouter', {}).get('enabled', False):
+            try:
+                from ai_providers.openrouter_provider import OpenRouterProvider
+                self.providers['openrouter'] = OpenRouterProvider(ai_config['openrouter'])
+                logger.info("OpenRouter provider initialized")
+            except Exception as e:
+                logger.warning(f"Failed to initialize OpenRouter provider: {e}")
 
     
     def set_provider(self, provider_name: str) -> bool:

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -43,6 +43,15 @@ ai_providers:
     max_tokens: 2000
     timeout: 60
 
+  openrouter:
+    enabled: true
+    api_key: "sk-or-v1-your-openrouter-api-key-here"
+    base_url: "https://openrouter.ai/api/v1"
+    model: "openai/gpt-4o"  
+    temperature: 0.7
+    max_tokens: 2000
+    timeout: 30
+
 # Scanner Settings
 scanner:
   # Target configuration
@@ -64,7 +73,7 @@ scanner:
   quick_scan: false    # Quick scan (basic tests only)
   
   # AI Provider selection
-  ai_provider: "openai"  # Options: openai, claude, grok, ollama
+  ai_provider: "openai"  # Options: openai, claude, grok, ollama, mistral, openrouter
   
   # Network settings
   proxy: ""  # Proxy URL (e.g., http://127.0.0.1:8080)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,6 +26,7 @@ deep-eye/
 │   ├── __init__.py
 │   ├── provider_manager.py    # Provider management
 │   ├── openai_provider.py     # OpenAI/GPT-4 integration
+│   ├── openrouter_provider.py # OpenRouter integration
 │   ├── claude_provider.py     # Anthropic Claude integration
 │   ├── grok_provider.py       # xAI Grok integration
 │   └── ollama_provider.py     # OLLAMA local LLM integration

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -81,6 +81,17 @@ ai_providers:
     model: "llama2"
 ```
 
+#### OpenRouter
+1. Get API key from https://openrouter.ai/settings/keys
+2. Add to config.yaml:
+```yaml
+ai_providers:
+  openrouter:
+    enabled: true
+    api_key: "sk-your-key-here"
+    model: "openai/gpt-4o"
+```
+
 ## Command Line Options
 
 | Option | Description | Example |


### PR DESCRIPTION
Add OpenRouter support as a new AI provider.

Changes:
- Create ai_providers/openrouter_provider.py
- Update provider_manager.py to initialize OpenRouter
- Update config.example.yaml with OpenRouter configuration
- Add "openrouter" to ai_provider options list

Now you can use OpenRouter by setting ai_provider: "openrouter" in config.