### PR TITLE
chore: remove deprecated asyncio PyPI backport from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,8 @@ mistralai>=1.0.0
 
 # Async Support
 aiohttp>=3.9.0
-asyncio>=3.4.3
+# Note: asyncio is part of the Python standard library since 3.4.
+# The PyPI backport package is deprecated and unnecessary on Python 3.8+.
 
 # Web Crawling & Parsing
 selenium>=4.15.0


### PR DESCRIPTION
## Summary
- Removed `asyncio>=3.4.3` from `requirements.txt`
- `asyncio` is part of the Python standard library since 3.4 — the PyPI backport is deprecated and unmaintained (~2015)
- Since this project requires Python 3.8+, the backport is unnecessary

## Security Impact
Installing deprecated, unmaintained packages increases supply chain attack surface. If the PyPI `asyncio` package name were ever hijacked, all users installing from `requirements.txt` would be affected.

## Changes
- `requirements.txt`: Replaced `asyncio>=3.4.3` with a comment explaining why it was removed

## Test plan
- [ ] `pip install -r requirements.txt` completes without errors
- [ ] `import asyncio` still works (stdlib)
- [ ] Full scan runs without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)