### PR TITLE
feat: add LiteLLM as AI provider

### DIFF
--- a/ai_providers/litellm_provider.py
+++ b/ai_providers/litellm_provider.py
@@ -1,0 +1,68 @@
+"""
+LiteLLM Provider
+
+Routes to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, Bedrock,
+Ollama, etc.) via the litellm SDK. No proxy server needed.
+
+Model strings use the provider/model format, e.g.
+anthropic/claude-sonnet-4-20250514, azure/gpt-4o, openai/gpt-4o.
+
+See https://docs.litellm.ai/docs/providers for all supported models.
+"""
+
+from typing import Dict
+
+import litellm
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class LiteLLMProvider:
+    """LiteLLM API provider for 100+ LLM providers."""
+
+    def __init__(self, config: Dict):
+        """Initialize LiteLLM provider."""
+        self.config = config
+        self.api_key = config.get("api_key")
+        self.model = config.get("model", "openai/gpt-4o")
+        self.temperature = config.get("temperature", 0.7)
+        self.max_tokens = config.get("max_tokens", 2000)
+
+    def generate(self, prompt: str, **kwargs) -> str:
+        """
+        Generate response using LiteLLM.
+
+        Args:
+            prompt: Input prompt
+            **kwargs: Additional arguments
+
+        Returns:
+            Generated response
+        """
+        try:
+            params = {
+                "model": kwargs.get("model", self.model),
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are a security expert specializing in penetration testing and vulnerability research.",
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+                "temperature": kwargs.get("temperature", self.temperature),
+                "max_tokens": kwargs.get("max_tokens", self.max_tokens),
+                "drop_params": True,
+            }
+
+            if self.api_key:
+                params["api_key"] = self.api_key
+
+            response = litellm.completion(**params)
+
+            return response.choices[0].message.content
+
+        except Exception as e:
+            logger.error(f"LiteLLM generation error: {e}")
+            raise

--- a/ai_providers/provider_manager.py
+++ b/ai_providers/provider_manager.py
@@ -105,6 +105,15 @@ class AIProviderManager:
             except Exception as e:
                 logger.warning(f"Failed to initialize LM Studio provider: {e}")
 
+        # LiteLLM
+        if ai_config.get('litellm', {}).get('enabled', False):
+            try:
+                from ai_providers.litellm_provider import LiteLLMProvider
+                self.providers['litellm'] = LiteLLMProvider(ai_config['litellm'])
+                logger.info("LiteLLM provider initialized")
+            except Exception as e:
+                logger.warning(f"Failed to initialize LiteLLM provider: {e}")
+
     
     def set_provider(self, provider_name: str) -> bool:
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ anthropic>=0.18.0
 ollama>=0.1.6
 mistralai>=1.0.0
 google-genai>=0.8.0
+litellm>=1.60.0,<2.0.0
 
 # Async Support
 aiohttp>=3.9.0

--- a/tests/e2e_litellm.py
+++ b/tests/e2e_litellm.py
@@ -1,0 +1,74 @@
+"""Live E2E test for LiteLLM provider.
+
+Requires API key. Set ANTHROPIC_FOUNDRY_API_KEY and ANTHROPIC_FOUNDRY_BASE_URL,
+or ANTHROPIC_API_KEY, or OPENAI_API_KEY.
+
+Usage:
+    PYTHONPATH=. python tests/e2e_litellm.py
+"""
+
+import os
+import sys
+
+
+def main():
+    api_key = (
+        os.environ.get("ANTHROPIC_FOUNDRY_API_KEY")
+        or os.environ.get("ANTHROPIC_API_KEY")
+        or os.environ.get("OPENAI_API_KEY")
+    )
+    if not api_key:
+        print("SKIP: no API key found")
+        sys.exit(0)
+
+    base_url = os.environ.get("ANTHROPIC_FOUNDRY_BASE_URL")
+    if base_url:
+        import litellm
+        litellm.api_base = base_url
+
+    from ai_providers.litellm_provider import LiteLLMProvider
+
+    provider = LiteLLMProvider({
+        "api_key": api_key,
+        "model": "anthropic/claude-sonnet-4-6",
+    })
+
+    # Test 1: Basic generation
+    result = provider.generate("What is 2+2? Reply with just the number.")
+    print(f"Test 1 (basic): \"{result.strip()}\"")
+    assert "4" in result, f"Expected 4, got: {result}"
+
+    # Test 2: kwargs override
+    result2 = provider.generate("Say OK", max_tokens=5, temperature=0)
+    print(f"Test 2 (kwargs): \"{result2.strip()}\"")
+    assert result2.strip(), "Empty response"
+
+    # Test 3: Security system prompt works
+    result3 = provider.generate("List one common web vulnerability in one word.")
+    print(f"Test 3 (security): \"{result3.strip()[:50]}\"")
+    assert result3.strip(), "Empty response"
+
+    # Test 4: Provider manager integration
+    from ai_providers.provider_manager import AIProviderManager
+
+    config = {
+        "ai_providers": {
+            "litellm": {
+                "enabled": True,
+                "api_key": api_key,
+                "model": "anthropic/claude-sonnet-4-6",
+            }
+        }
+    }
+    manager = AIProviderManager(config)
+    assert manager.set_provider("litellm")
+    result4 = manager.generate("Say hello in one word.")
+    print(f"Test 4 (manager): \"{result4.strip()[:30]}\"")
+    assert result4.strip(), "Empty response from manager"
+
+    print()
+    print("ALL 4 E2E TESTS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 class TestLiteLLMProviderInit:
     def test_default_model(self):
@@ -91,6 +93,70 @@ class TestLiteLLMProviderGenerate:
         kwargs = mock_litellm.completion.call_args.kwargs
         assert kwargs["model"] == "anthropic/claude-haiku-4-5"
         assert kwargs["temperature"] == 0.2
+
+
+class TestLiteLLMProviderEdgeCases:
+    @patch("ai_providers.litellm_provider.litellm")
+    def test_raises_on_api_error(self, mock_litellm):
+        mock_litellm.completion.side_effect = Exception("401 Unauthorized")
+
+        from ai_providers.litellm_provider import LiteLLMProvider
+
+        p = LiteLLMProvider({"api_key": "bad-key"})
+        with pytest.raises(Exception, match="401"):
+            p.generate("hello")
+
+    @patch("ai_providers.litellm_provider.litellm")
+    def test_returns_none_content_gracefully(self, mock_litellm):
+        mock_msg = MagicMock(content=None)
+        mock_litellm.completion.return_value = MagicMock(
+            choices=[MagicMock(message=mock_msg)]
+        )
+
+        from ai_providers.litellm_provider import LiteLLMProvider
+
+        p = LiteLLMProvider({"api_key": "sk-test"})
+        result = p.generate("hello")
+        assert result is None
+
+    @patch("ai_providers.litellm_provider.litellm")
+    def test_provider_manager_can_load_litellm(self, mock_litellm):
+        from ai_providers.provider_manager import AIProviderManager
+
+        config = {
+            "ai_providers": {
+                "litellm": {
+                    "enabled": True,
+                    "api_key": "sk-test",
+                    "model": "openai/gpt-4o",
+                }
+            }
+        }
+        manager = AIProviderManager(config)
+        assert "litellm" in manager.get_available_providers()
+
+    @patch("ai_providers.litellm_provider.litellm")
+    def test_provider_manager_generate_routes_to_litellm(self, mock_litellm):
+        mock_msg = MagicMock(content="manager response")
+        mock_litellm.completion.return_value = MagicMock(
+            choices=[MagicMock(message=mock_msg)]
+        )
+
+        from ai_providers.provider_manager import AIProviderManager
+
+        config = {
+            "ai_providers": {
+                "litellm": {
+                    "enabled": True,
+                    "api_key": "sk-test",
+                    "model": "openai/gpt-4o",
+                }
+            }
+        }
+        manager = AIProviderManager(config)
+        manager.set_provider("litellm")
+        result = manager.generate("test prompt")
+        assert result == "manager response"
 
 
 class TestRegistration:

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,104 @@
+"""Tests for LiteLLM provider."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+class TestLiteLLMProviderInit:
+    def test_default_model(self):
+        from ai_providers.litellm_provider import LiteLLMProvider
+
+        p = LiteLLMProvider({"api_key": "sk-test"})
+        assert p.model == "openai/gpt-4o"
+
+    def test_custom_model(self):
+        from ai_providers.litellm_provider import LiteLLMProvider
+
+        p = LiteLLMProvider({"model": "anthropic/claude-sonnet-4-20250514"})
+        assert p.model == "anthropic/claude-sonnet-4-20250514"
+
+    def test_api_key_stored(self):
+        from ai_providers.litellm_provider import LiteLLMProvider
+
+        p = LiteLLMProvider({"api_key": "sk-test"})
+        assert p.api_key == "sk-test"
+
+    def test_default_temperature(self):
+        from ai_providers.litellm_provider import LiteLLMProvider
+
+        p = LiteLLMProvider({})
+        assert p.temperature == 0.7
+
+
+class TestLiteLLMProviderGenerate:
+    @patch("ai_providers.litellm_provider.litellm")
+    def test_calls_litellm_completion(self, mock_litellm):
+        mock_msg = MagicMock(content="test response")
+        mock_litellm.completion.return_value = MagicMock(
+            choices=[MagicMock(message=mock_msg)]
+        )
+
+        from ai_providers.litellm_provider import LiteLLMProvider
+
+        p = LiteLLMProvider({"api_key": "sk-test", "model": "openai/gpt-4o"})
+        result = p.generate("hello")
+
+        assert result == "test response"
+        kwargs = mock_litellm.completion.call_args.kwargs
+        assert kwargs["model"] == "openai/gpt-4o"
+        assert kwargs["drop_params"] is True
+        assert kwargs["api_key"] == "sk-test"
+
+    @patch("ai_providers.litellm_provider.litellm")
+    def test_omits_api_key_when_none(self, mock_litellm):
+        mock_msg = MagicMock(content="ok")
+        mock_litellm.completion.return_value = MagicMock(
+            choices=[MagicMock(message=mock_msg)]
+        )
+
+        from ai_providers.litellm_provider import LiteLLMProvider
+
+        p = LiteLLMProvider({"model": "openai/gpt-4o"})
+        p.generate("hi")
+        assert "api_key" not in mock_litellm.completion.call_args.kwargs
+
+    @patch("ai_providers.litellm_provider.litellm")
+    def test_system_prompt_is_security_expert(self, mock_litellm):
+        mock_msg = MagicMock(content="ok")
+        mock_litellm.completion.return_value = MagicMock(
+            choices=[MagicMock(message=mock_msg)]
+        )
+
+        from ai_providers.litellm_provider import LiteLLMProvider
+
+        p = LiteLLMProvider({"api_key": "sk-test"})
+        p.generate("test")
+        messages = mock_litellm.completion.call_args.kwargs["messages"]
+        assert messages[0]["role"] == "system"
+        assert "security" in messages[0]["content"].lower()
+
+    @patch("ai_providers.litellm_provider.litellm")
+    def test_forwards_kwargs(self, mock_litellm):
+        mock_msg = MagicMock(content="ok")
+        mock_litellm.completion.return_value = MagicMock(
+            choices=[MagicMock(message=mock_msg)]
+        )
+
+        from ai_providers.litellm_provider import LiteLLMProvider
+
+        p = LiteLLMProvider({"api_key": "sk-test"})
+        p.generate("test", model="anthropic/claude-haiku-4-5", temperature=0.2)
+        kwargs = mock_litellm.completion.call_args.kwargs
+        assert kwargs["model"] == "anthropic/claude-haiku-4-5"
+        assert kwargs["temperature"] == 0.2
+
+
+class TestRegistration:
+    def test_litellm_in_provider_manager(self):
+        src = Path("ai_providers/provider_manager.py").read_text()
+        assert "litellm" in src
+        assert "LiteLLMProvider" in src
+
+    def test_litellm_in_requirements(self):
+        reqs = Path("requirements.txt").read_text()
+        assert "litellm" in reqs


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
  - Adds LiteLLM as a new AI provider, enabling access to 100+ providers (OpenAI, Anthropic, Google, Azure, Bedrock, Ollama, etc.) via a single unified SDK
  - New `LiteLLMProvider` in `ai_providers/litellm_provider.py` following the exact same pattern as `OpenAIProvider`, `ClaudeProvider`, etc.                                                                         
  - Registered in `provider_manager.py` alongside all existing providers                                                                                                                                             
                                                                                                                                                                                                                     
  ## Changes                                                                                                                                                                                                         
  - `ai_providers/litellm_provider.py` - new `LiteLLMProvider` with `litellm.completion()`, `drop_params=True`, same `generate(prompt)` interface as all other providers                                             
  - `ai_providers/provider_manager.py` - added litellm initialization block                                                                                                                                          
  - `requirements.txt` - added `litellm>=1.60.0,<2.0.0`                                                                                                                                                              
  - `tests/test_litellm_provider.py` - 14 unit tests (all passing)                                                                                                                                                   
  - `tests/e2e_litellm.py` - 4 live E2E tests against real API                                                                                                                                                       
                                                                                                                                                                                                                     
  ## Tests
                                                                                                                                                                                                                     
  **Unit tests (14/14 passing):**
  ```
  $ python -m pytest tests/test_litellm_provider.py -v                                                                                                                                                               
  test_default_model PASSED
  test_custom_model PASSED                                                                                                                                                                                           
  test_api_key_stored PASSED
  test_default_temperature PASSED                                                                                                                                                                                    
  test_calls_litellm_completion PASSED
  test_omits_api_key_when_none PASSED                                                                                                                                                                                
  test_system_prompt_is_security_expert PASSED
  test_forwards_kwargs PASSED
  test_raises_on_api_error PASSED
  test_returns_none_content_gracefully PASSED                                                                                                                                                                        
  test_provider_manager_can_load_litellm PASSED
  test_provider_manager_generate_routes_to_litellm PASSED                                                                                                                                                            
  test_litellm_in_provider_manager PASSED
  test_litellm_in_requirements PASSED                                                                                                                                                                                
  14 passed in 1.21s
  ```                                                                                                                                                                                                                
                  
  **Live E2E tests (4/4 passing against real API):**
  ```
  $ PYTHONPATH=. python tests/e2e_litellm.py
  Test 1 (basic): "4"                                                                                                                                                                                                
  Test 2 (kwargs): "OK"
  Test 3 (security): "**SQLinjection**"                                                                                                                                                                              
  Test 4 (manager): "Hello!"
                                                                                                                                                                                                                     
  ALL 4 E2E TESTS PASSED
  ```                                                                                                                                                                                                                
                  
  Tests verified the full chain: `AIProviderManager` -> `LiteLLMProvider.generate()` -> `litellm.completion()` -> Azure Foundry -> Anthropic Claude -> response parsed.                                              
   
  ## Example usage                                                                                                                                                                                                   
                  
  ```yaml                                                                                                                                                                                                            
  # config.yaml   
  ai_providers:
    litellm:
      enabled: true
      model: "anthropic/claude-sonnet-4-20250514"
      # LiteLLM reads provider keys from env automatically                                                                                                                                                           
      # (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)
  ```                                                                                                                                                                                                                
                  
  ```python                                                                                                                                                                                                          
  from ai_providers.litellm_provider import LiteLLMProvider
                                                                                                                                                                                                                     
  provider = LiteLLMProvider({
      "model": "anthropic/claude-sonnet-4-20250514",                                                                                                                                                                 
      # api_key optional, litellm reads from env
  })                                                                                                                                                                                                                 
  result = provider.generate("Analyze this endpoint for SQL injection vulnerabilities...")
  print(result)                                                                                                                                                                                                      
  ```             
                                                                                                                                                                                                                     
  ```python       
  # Or through the provider manager
  from ai_providers.provider_manager import AIProviderManager                                                                                                                                                        
   
  manager = AIProviderManager(config)                                                                                                                                                                                
  manager.set_provider("litellm")
  result = manager.generate("Scan for XSS vulnerabilities in this form...")
  ```                                                                                                                                                                                                                
   
  See https://docs.litellm.ai/docs/providers for 100+ supported model strings.                                                                                                                                       
                  
  ## Impact                                                                                                                                                                                                          
  - Additive only, existing providers (openai, claude, grok, groq, gemini, mistral, ollama, openrouter, lmstudio) untouched
  - `litellm` added to requirements.txt                                                                                                                                                                              
  - `drop_params=True` silently drops provider-unsupported kwargs
  - Same `generate(prompt, **kwargs)` interface as all other providers                                                                                                                                               
