### PR TITLE
Add Requesty as an AI provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ python tests/e2e_litellm.py                         # e2e test (requires API key
 | Layer | Purpose |
 |-------|---------|
 | `core/` | Orchestration: scanner engine, vuln scanner, AI payload gen, report gen, state manager, subdomain scanner, plugin manager, scan diff |
-| `ai_providers/` | Unified interface to OpenAI, Claude, Grok, OLLAMA, Gemini, Groq, Mistral, OpenRouter, LiteLLM, LM Studio. All implement `generate(prompt, **kwargs) -> str` |
+| `ai_providers/` | Unified interface to OpenAI, Claude, Grok, OLLAMA, Gemini, Groq, Mistral, OpenRouter, Requesty, LiteLLM, LM Studio. All implement `generate(prompt, **kwargs) -> str` |
 | `modules/` | Specialized testers (see Module Categories below) |
 | `utils/` | http_client, config_loader, parser, logger, notification_manager, exports (JUnit/CSV/XLSX), compliance mapper, scope_manager, oast_server, ai_summary_generator |
 | `scripts/` | CVE database updater, RAG index builder, notification tester |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-Deep Eye orchestrates multiple AI providers (OpenAI, Claude, Grok, Gemini, OLLAMA, Groq, Mistral, OpenRouter, LiteLLM, LM Studio) for intelligent payload generation, scans targets for 45+ vulnerability types, and produces professional reports with compliance mapping.
+Deep Eye orchestrates multiple AI providers (OpenAI, Claude, Grok, Gemini, OLLAMA, Groq, Mistral, OpenRouter, Requesty, LiteLLM, LM Studio) for intelligent payload generation, scans targets for 45+ vulnerability types, and produces professional reports with compliance mapping.
 
 ## Features
 
@@ -145,7 +145,7 @@ ai_providers:
     model: "llama2"
 ```
 
-Supported: `openai`, `claude`, `grok`, `ollama`, `gemini`, `openrouter`, `mistral`, `groq`, `lmstudio`, `litellm`
+Supported: `openai`, `claude`, `grok`, `ollama`, `gemini`, `openrouter`, `requesty`, `mistral`, `groq`, `lmstudio`, `litellm`
 
 ### Scanner Settings
 

--- a/ai_providers/provider_manager.py
+++ b/ai_providers/provider_manager.py
@@ -78,6 +78,15 @@ class AIProviderManager:
             except Exception as e:
                 logger.warning(f"Failed to initialize OpenRouter provider: {e}")
 
+        # Requesty
+        if ai_config.get('requesty', {}).get('enabled', False):
+            try:
+                from ai_providers.requesty_provider import RequestyProvider
+                self.providers['requesty'] = RequestyProvider(ai_config['requesty'])
+                logger.info("Requesty provider initialized")
+            except Exception as e:
+                logger.warning(f"Failed to initialize Requesty provider: {e}")
+
         
         # Gemini
         if ai_config.get('gemini', {}).get('enabled', False):

--- a/ai_providers/requesty_provider.py
+++ b/ai_providers/requesty_provider.py
@@ -1,0 +1,73 @@
+"""
+Requesty Provider
+"""
+
+from typing import Dict, Optional
+from openai import OpenAI
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class RequestyProvider:
+    """Requesty API provider."""
+    
+    def __init__(self, config: Dict):
+        """Initialize Requesty provider."""
+        self.config = config
+        self.api_key = config.get('api_key')
+        self.model = config.get('model', 'openai/gpt-4o-mini')
+        self.temperature = config.get('temperature', 0.7)
+        self.max_tokens = config.get('max_tokens', 2000)
+        self.site_url = config.get('site_url', 'https://github.com/zakirkun/deep-eye')
+        self.site_name = config.get('site_name', 'Deep Eye')
+        
+        if not self.api_key:
+            raise ValueError("Requesty API key not provided")
+        
+        # Initialize OpenAI client with Requesty base URL
+        self.client = OpenAI(
+            base_url="https://router.requesty.ai/v1",
+            api_key=self.api_key,
+        )
+    
+    def generate(self, prompt: str, **kwargs) -> str:
+        """
+        Generate response using Requesty.
+        
+        Args:
+            prompt: Input prompt
+            **kwargs: Additional arguments
+            
+        Returns:
+            Generated response
+        """
+        try:
+            # Add Requesty specific headers
+            extra_headers = {
+                "HTTP-Referer": self.site_url,
+                "X-Title": self.site_name,
+            }
+            
+            response = self.client.chat.completions.create(
+                model=kwargs.get('model', self.model),
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "You are a security expert specializing in penetration testing and vulnerability research."
+                    },
+                    {
+                        "role": "user",
+                        "content": prompt
+                    }
+                ],
+                temperature=kwargs.get('temperature', self.temperature),
+                max_tokens=kwargs.get('max_tokens', self.max_tokens),
+                extra_headers=extra_headers
+            )
+            
+            return response.choices[0].message.content
+        
+        except Exception as e:
+            logger.error(f"Requesty generation error: {e}")
+            raise

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -64,12 +64,23 @@ ai_providers:
 
   openrouter:
     enabled: true
-    api_key: "sk-or-v1-your-openrouter-api-key-here"
+    api_key: "sk-or-...here"
     base_url: "https://openrouter.ai/api/v1"
     model: "openai/gpt-4o"  
     temperature: 0.7
     max_tokens: 2000
     timeout: 30
+
+  requesty:
+    enabled: false
+    api_key: "sk-...here"
+    base_url: "https://router.requesty.ai/v1"
+    model: "openai/gpt-4o-mini"
+    temperature: 0.7
+    max_tokens: 2000
+    timeout: 30
+    site_url: "https://github.com/zakirkun/deep-eye"
+    site_name: "Deep Eye"
 
   # Gemini (Google)
   gemini:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,7 +63,7 @@ All providers implement: `generate(prompt, **kwargs) -> str`
 
 `provider_manager.py` handles: provider selection, failover, retry logic, API key management.
 
-Providers: OpenAI, Claude, Grok, OLLAMA, Gemini, OpenRouter, Mistral, Groq, LM Studio, LiteLLM.
+Providers: OpenAI, Claude, Grok, OLLAMA, Gemini, OpenRouter, Requesty, Mistral, Groq, LM Studio, LiteLLM.
 
 ### `modules/` — Specialized Testers
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -46,9 +46,29 @@ ai_providers:
     base_url: "http://localhost:11434"
     model: "llama2"
     timeout: 60
+
+  openrouter:
+    enabled: false
+    api_key: "sk-or-..."
+    model: "openai/gpt-4o"
+    temperature: 0.7
+    max_tokens: 2000
+    timeout: 30
+
+  requesty:
+    enabled: false
+    api_key: "sk-..."          # Get a key at https://app.requesty.ai/api-keys
+    model: "openai/gpt-4o-mini"
+    temperature: 0.7
+    max_tokens: 2000
+    timeout: 30
 ```
 
-Supported providers: `openai`, `claude`, `grok`, `ollama`, `gemini`, `openrouter`, `mistral`, `groq`, `lmstudio`, `litellm`
+Requesty (https://requesty.ai) is an OpenAI-compatible router. Deep Eye talks to it via
+`https://router.requesty.ai/v1` using your `REQUESTY_API_KEY`. Models use `provider/model`
+naming (e.g. `openai/gpt-4o-mini`).
+
+Supported providers: `openai`, `claude`, `grok`, `ollama`, `gemini`, `openrouter`, `requesty`, `mistral`, `groq`, `lmstudio`, `litellm`
 
 ### scanner
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -124,6 +124,15 @@ ai_providers:
     model: "openai/gpt-4o"
 ```
 
+### Requesty
+```yaml
+ai_providers:
+  requesty:
+    enabled: true
+    api_key: "sk-..."
+    model: "openai/gpt-4o-mini"
+```
+
 ### LiteLLM (Universal Proxy)
 ```yaml
 ai_providers:

--- a/utils/onboard.py
+++ b/utils/onboard.py
@@ -75,6 +75,12 @@ PROVIDERS = {
         "default_model": "local-model",
         "base_url": "http://localhost:1234/v1",
     },
+    "11": {
+        "key": "requesty",
+        "name": "Requesty",
+        "needs_key": True,
+        "default_model": "openai/gpt-4o-mini",
+    },
 }
 
 


### PR DESCRIPTION
Adds Requesty (https://requesty.ai) as an OpenAI-compatible AI provider, mirroring the existing OpenRouter provider.

- `ai_providers/requesty_provider.py`: new `RequestyProvider`, a faithful near-rename of `openrouter_provider.py` using the OpenAI SDK against `https://router.requesty.ai/v1` (default model `openai/gpt-4o-mini`, `HTTP-Referer`/`X-Title` supported).
- `ai_providers/provider_manager.py`: registration block mirroring the OpenRouter one (config key `requesty`).
- `utils/onboard.py`: Requesty option in the setup wizard.
- `config/config.example.yaml` + docs (`CONFIGURATION.md`, `QUICKSTART.md`, `ARCHITECTURE.md`, `README.md`, `CLAUDE.md`).

API keys: https://app.requesty.ai/api-keys

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.